### PR TITLE
Add flag to not load certs

### DIFF
--- a/lib/base.js
+++ b/lib/base.js
@@ -21,14 +21,16 @@ const PROMISIFIED_SUFFIX = 'Async'
 // and then reading files can lead to race conditions (unlikely, but still)
 const certs = {}
 
-try {
-  // DOCKER_CERT_PATH is docker's default thing it checks - may as well use it
-  const certPath = process.env.DOCKER_CERT_PATH || '/etc/ssl/docker'
-  certs.ca = fs.readFileSync(join(certPath, '/ca.pem'))
-  certs.cert = fs.readFileSync(join(certPath, '/cert.pem'))
-  certs.key = fs.readFileSync(join(certPath, '/key.pem'))
-} catch (e) {
-  throw e
+if (!process.env.DOCKER_USE_HTTP) {
+  try {
+    // DOCKER_CERT_PATH is docker's default thing it checks - may as well use it
+    const certPath = process.env.DOCKER_CERT_PATH || '/etc/ssl/docker'
+    certs.ca = fs.readFileSync(join(certPath, '/ca.pem'))
+    certs.cert = fs.readFileSync(join(certPath, '/cert.pem'))
+    certs.key = fs.readFileSync(join(certPath, '/key.pem'))
+  } catch (e) {
+    throw e
+  }
 }
 
 const optsSchema = joi.object({
@@ -96,7 +98,8 @@ class BaseDockerClient {
     const logData = {
       containerId: containerId,
       action: action,
-      opts: opts
+      opts: opts,
+      method: '_containerAction'
     }
     const log = this.log.child(logData)
     log.debug('call')


### PR DESCRIPTION
Add flag to disable certs loading.
I need this because sometimes we use dockermock and docker-mock doesn't support https
